### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 Any AI can backtest a strategy. VARRD guarantees it was done right — with K-tracking, Bonferroni correction, OOS lock, lookahead detection, and 4 other integrity guardrails enforced at infrastructure level.
 
+<a href="https://glama.ai/mcp/servers/@augiemazza/varrd">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@augiemazza/varrd/badge" alt="Varrd MCP server" />
+</a>
+
 ---
 
 ## MCP Server — 7 Tools, 4 Prompts


### PR DESCRIPTION
This PR adds a badge for the [Varrd](https://glama.ai/mcp/servers/@augiemazza/varrd) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@augiemazza/varrd">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@augiemazza/varrd/badge" alt="Varrd MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.